### PR TITLE
[IIIF-628] Add idle timeout argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,5 +4,6 @@ resource "aws_lb" "alb_main" {
   load_balancer_type = "application"
   subnets            = "${var.vpc_subnet_ids}"
   security_groups    = "${var.alb_security_groups}"
+  idle_timeout       = "${var.idle_timeout}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,5 @@
 variable "alb_name" {}
 variable "alb_security_groups" {}
 variable "vpc_subnet_ids" {}
+variable "idle_timeout" { default = "60" }
 


### PR DESCRIPTION
Configure the AWS Load Balancer module to make adjusting timeouts configurable.